### PR TITLE
[Feature] BOJ 문제 조회 및 노션 DB 기반 기록 관리 기능 구현

### DIFF
--- a/components/Button.js
+++ b/components/Button.js
@@ -1,12 +1,16 @@
 export class Button {
-  constructor(type, text) {
+  constructor(type, text, className, id) {
+    this.type = type;
     this.text = text;
+    this.className = className;
+    this.id = id;
   }
 
   render() {
     const button = document.createElement("button");
     button.type = this.type;
-    button.className = "submit-btn";
+    button.className = this.className;
+    button.id = this.id;
     button.textContent = this.text;
 
     return button;

--- a/components/RangeSlider.js
+++ b/components/RangeSlider.js
@@ -1,4 +1,4 @@
-import { TIER_IMAGE_BASE_URL } from "../constants/config.js";
+import { TIER_IMAGE_BASE_URL } from "../constants/url.js";
 
 export class RangeSlider {
   constructor({ id, min, max }) {
@@ -20,8 +20,8 @@ export class RangeSlider {
         <div class="range-handle" id="end-handle"></div>
       </div>
       <div style="display: flex; justify-content: space-between;">
-        <img id="start-tier-image" class="tier-image" src="${TIER_IMAGE_BASE_URL}/${this.min}.svg" alt="Start Tier" width="20" />
-        <img id="end-tier-image" class="tier-image" src="${TIER_IMAGE_BASE_URL}/${this.max}.svg" alt="End Tier" width="20" />
+        <img id="start-tier-image" class="tier-image" src="${TIER_IMAGE_BASE_URL}${this.min}.svg" alt="Start Tier" width="20" />
+        <img id="end-tier-image" class="tier-image" src="${TIER_IMAGE_BASE_URL}${this.max}.svg" alt="End Tier" width="20" />
       </div>
     `;
 

--- a/constants/config.js
+++ b/constants/config.js
@@ -1,23 +1,37 @@
-const algorithmMap = {
-  5: "백트래킹",
-  25: "DP",
-  33: "그리디",
-  97: "정렬",
-  102: "구현",
-  124: "수학",
-  125: "완전 탐색",
-  126: "BFS",
-  127: "DFS",
-  175: "자료구조",
+export const algorithmMap = {
+  backtracking: "백트래킹",
+  dp: "DP",
+  greedy: "그리디",
+  sorting: "정렬",
+  implementation: "구현",
+  math: "수학",
+  bruteforcing: "완전 탐색",
+  bfs: "BFS",
+  dfs: "DFS",
+  data_structures: "자료구조",
 };
 
-export const ALGORITHM_OPTIONS = Object.entries(algorithmMap)
-  .map(([value, label]) => ({ value: parseInt(value), label }))
-  .sort((a, b) => a.id - b.id);
+const tiers = ["Bronze", "Silver", "Gold", "Platinum", "Diamond", "Ruby"];
+const romanNumerals = ["I", "II", "III", "IV", "V"];
+
+export const TIER_COLOR = ["brown", "gray", "yellow", "purple", "blue", "red"];
+
+export const LEVEL = Object.fromEntries(
+  Array.from({ length: 30 }, (_, i) => {
+    const level = i + 1;
+
+    const tierIndex = Math.floor((level - 1) / 5);
+    const romanIndex = (level - 1) % 5;
+
+    return [level, tiers[tierIndex] + romanNumerals[romanIndex]];
+  })
+);
+
+export const ALGORITHM_OPTIONS = Object.entries(algorithmMap).map(
+  ([value, label]) => ({ value, label })
+);
 
 export const PROBLEM_COUNT_OPTIONS = Array.from({ length: 100 }, (_, i) => ({
   value: String(i + 1),
   label: String(i + 1),
 }));
-
-export const TIER_IMAGE_BASE_URL = "https://d2gd6pc034wcta.cloudfront.net/tier";

--- a/constants/url.js
+++ b/constants/url.js
@@ -1,0 +1,10 @@
+export const PROXY_URL =
+  "https://panicky-arabella-cors-anywhere-c4eef9e3.koyeb.app/proxy";
+export const BOJ_PROBLEM_URL = "https://www.acmicpc.net/problem/";
+
+export const TIER_IMAGE_BASE_URL =
+  "https://d2gd6pc034wcta.cloudfront.net/tier/";
+
+export const SOLVED_AC_URL = "https://solved.ac/api/v3/search/problem";
+export const NOTION_PAGE_URL = "https://api.notion.com/v1/pages/";
+export const NOTION_DARABASE_URL = "https://api.notion.com/v1/databases/";

--- a/core/crawler/BojProblemFetcher.js
+++ b/core/crawler/BojProblemFetcher.js
@@ -1,0 +1,37 @@
+import { PROXY_URL, SOLVED_AC_URL } from "../../constants/url.js";
+import { NotionPropertiesDTO } from "../dto/NotionPropertiesDTO.js";
+import { NotionDatabaseManager } from "../notion/NotionDatabaseManager.js";
+
+export class BojProblemFetcher {
+  constructor() {
+    this.notionDatabaseManager = new NotionDatabaseManager();
+  }
+
+  async fetchProblems(tag, startLevel, endLevel, number) {
+    console.log("start");
+    const response = await fetch(PROXY_URL, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        url: `${SOLVED_AC_URL}?query=tag:${tag}+tier:${startLevel}&sort=solved&direction=desc`,
+        headers: {
+          "x-solvedac-language": "ko",
+        },
+      }),
+    });
+    const data = await response.json();
+    console.log(data.items.length);
+    const notionProperties = data.items.map((item) =>
+      NotionPropertiesDTO.of(item)
+    );
+    console.log(notionProperties);
+
+    await this.notionDatabaseManager.setSchema();
+
+    await notionProperties.forEach((properties) => {
+      this.notionDatabaseManager.addProblem(properties);
+    });
+  }
+}

--- a/core/dto/NotionPropertiesDTO.js
+++ b/core/dto/NotionPropertiesDTO.js
@@ -1,0 +1,45 @@
+import { algorithmMap, LEVEL, TIER_COLOR } from "../../constants/config.js";
+import { BOJ_PROBLEM_URL } from "../../constants/url.js";
+
+export class NotionPropertiesDTO {
+  constructor(problemId, level, name, algorithmTags) {
+    this.problemId = problemId;
+    this.level = level;
+    this.name = name;
+    this.algorithmTags = algorithmTags
+      .filter((tag) => tag in algorithmMap)
+      .map((tag) => algorithmMap[tag])
+      .map((tag) => ({ name: tag }));
+  }
+
+  static of(item) {
+    if (!item) {
+      return null;
+    }
+
+    const { problemId, level, titleKo, tags } = item;
+    const tagKeys = tags.map((tag) => tag.key);
+    console.log(tagKeys);
+    return new NotionPropertiesDTO(problemId, level, titleKo, tagKeys);
+  }
+
+  toJson() {
+    return {
+      이름: {
+        title: [{ text: { content: this.name } }],
+      },
+      알고리즘: {
+        multi_select: this.algorithmTags,
+      },
+      문제: {
+        url: `${BOJ_PROBLEM_URL}${this.problemId}`,
+      },
+      난이도: {
+        select: {
+          name: LEVEL[this.level],
+          color: TIER_COLOR[Math.floor((this.level - 1) / 5)],
+        },
+      },
+    };
+  }
+}

--- a/core/notion/NotionDatabaseManager.js
+++ b/core/notion/NotionDatabaseManager.js
@@ -1,0 +1,75 @@
+import {
+  NOTION_DARABASE_URL,
+  NOTION_PAGE_URL,
+  PROXY_URL,
+} from "../../constants/url.js";
+import { sleep } from "../../utils/sleep.js";
+
+export class NotionDatabaseManager {
+  constructor() {}
+
+  async addProblem(problem) {
+    await fetch(PROXY_URL, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        url: NOTION_PAGE_URL,
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${sessionStorage.getItem("notionApiToken")}`,
+          "Notion-Version": "2022-06-28",
+        },
+        body: {
+          parent: { database_id: sessionStorage.getItem("notionDatabaseId") },
+          properties: problem.toJson(),
+        },
+      }),
+    });
+
+    await sleep(500);
+  }
+
+  async setSchema() {
+    await fetch(PROXY_URL, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        url: `${NOTION_DARABASE_URL}${sessionStorage.getItem(
+          "notionDatabaseId"
+        )}`,
+        method: "PATCH",
+        headers: {
+          Authorization: `Bearer ${sessionStorage.getItem("notionApiToken")}`,
+          "Notion-Version": "2022-06-28",
+        },
+        body: {
+          parent: { database_id: sessionStorage.getItem("notionDatabaseId") },
+          properties: {
+            알고리즘: {
+              multi_select: {},
+            },
+            문제: {
+              url: {},
+            },
+            난이도: {
+              select: {},
+            },
+            "풀이 시간 (분)": {
+              number: {},
+            },
+            "푼 날짜": {
+              date: {},
+            },
+            비고: {
+              text: {},
+            },
+          },
+        },
+      }),
+    });
+  }
+}

--- a/index.html
+++ b/index.html
@@ -24,12 +24,14 @@
             placeholder="Notion API 토큰을 입력해주세요."
             required
           />
-          <small class="input-hint">예: asdjnqldms9oij2k3</small>
+          <small class="input-hint"
+            >예: ntn-1289275814801asdjnqldms9oij2k3</small
+          >
         </div>
 
         <div class="input-group">
           <input
-            type="text"
+            type="url"
             id="notion-database-link-input"
             class="input-field"
             placeholder="Notion 데이터베이스 페이지 URL을 입력해주세요."

--- a/main.js
+++ b/main.js
@@ -29,7 +29,18 @@ document.addEventListener("DOMContentLoaded", () => {
     placeholder: "저장할 문제 수를 선택해주세요.",
   });
 
-  const submitButton = new Button("submit", "확인");
+  const submitButton = new Button(
+    "submit",
+    "확인",
+    "submit-btn",
+    "submit-button"
+  );
+  const startButton = new Button(
+    "button",
+    "문제 추출 시작",
+    "start-btn",
+    "start-button"
+  );
 
   form.addEventListener("submit", (event) => {
     event.preventDefault();
@@ -41,8 +52,9 @@ document.addEventListener("DOMContentLoaded", () => {
       .getElementById("notion-database-link-input")
       .value.trim();
 
+    const databaseId = new URL(databaseUrl).pathname.split("/")[1];
     sessionStorage.setItem("notionApiToken", notionToken);
-    sessionStorage.setItem("notionDatabaseUrl", databaseUrl);
+    sessionStorage.setItem("notionDatabaseId", databaseId);
 
     const additionalForm = document.createElement("form");
     additionalForm.id = "additional-form";
@@ -59,8 +71,9 @@ document.addEventListener("DOMContentLoaded", () => {
     additionalForm.appendChild(
       InputWrapper.wrap(numberSelect.render(), "저장할 문제 수를 선택해주세요.")
     );
-    console.log(submitButton.render());
+
     additionalForm.appendChild(submitButton.render());
+    additionalForm.appendChild(startButton.render());
 
     main.innerHTML = additionalForm.outerHTML;
 

--- a/utils/formUtils.js
+++ b/utils/formUtils.js
@@ -1,4 +1,5 @@
-import { TIER_IMAGE_BASE_URL } from "../constants/config.js";
+import { TIER_IMAGE_BASE_URL } from "../constants/url.js";
+import { BojProblemFetcher } from "../core/crawler/BojProblemFetcher.js";
 
 export function initializeAdditionalForm() {
   let rangeStart = 1;
@@ -12,8 +13,8 @@ export function initializeAdditionalForm() {
   const endTierImage = document.getElementById("end-tier-image");
 
   function updateTierImages(start, end) {
-    startTierImage.src = `${TIER_IMAGE_BASE_URL}/${start}.svg`;
-    endTierImage.src = `${TIER_IMAGE_BASE_URL}/${end}.svg`;
+    startTierImage.src = `${TIER_IMAGE_BASE_URL}${start}.svg`;
+    endTierImage.src = `${TIER_IMAGE_BASE_URL}${end}.svg`;
   }
 
   function updateRange(handle, value) {
@@ -69,6 +70,7 @@ export function initializeAdditionalForm() {
     console.log("Additional form submitted");
 
     const selectedAlgorithm = document.getElementById("algorithm-select").value;
+    console.log(document.getElementById("algorithm-select").value);
     const selectedNumber = document.getElementById("number-select").value;
 
     if (!selectedAlgorithm || !selectedNumber) {
@@ -82,5 +84,21 @@ export function initializeAdditionalForm() {
     sessionStorage.setItem("selectedNumber", selectedNumber);
 
     alert("모든 선택이 완료되었습니다.");
+  });
+
+  const startButton = document.getElementById("start-button");
+  startButton.addEventListener("click", () => {
+    const selectedAlgorithm = sessionStorage.getItem("selectedAlgorithm");
+    const rangeStart = sessionStorage.getItem("rangeStart");
+    const rangeEnd = sessionStorage.getItem("rangeEnd");
+    const selectedNumber = sessionStorage.getItem("selectedNumber");
+
+    const problemFetcher = new BojProblemFetcher();
+    problemFetcher.fetchProblems(
+      selectedAlgorithm,
+      rangeStart,
+      rangeEnd,
+      selectedNumber
+    );
   });
 }

--- a/utils/sleep.js
+++ b/utils/sleep.js
@@ -1,0 +1,3 @@
+export function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}


### PR DESCRIPTION
## 관련 이슈
close #3 

## 설명
### BOJ 문제 조회
- solve.ac API 활용 (Reference : https://solvedac.github.io/unofficial-documentation/)
- 필터링 기능 추가 구현 필요

### 노션 DB 기반 기록 관리
- **Algorithm-Manager**에서 관리하는 형태로 DB Schema 변경
- Notion DB에 문제 추가
- Notion DB에 문제 추가 시, **`409 Confilct`** 오류를 방지하기 위해, 500ms의 sleep 추가 

## 작업 내용
- [x] tier, tag별 BOJ 문제 조회 기능 구현
- [x] Notion DB Schema 변경 기능
- [x] Notion DB에 문제 추가 기능
- [x] Notion DB에 문제 추가 시, 사이사이 sleep 추가 